### PR TITLE
Fix incorrect useState destructuring

### DIFF
--- a/src/HedgeCalculator.jsx
+++ b/src/HedgeCalculator.jsx
@@ -17,7 +17,7 @@ export default function HedgeCalculator() {
         { name: "Driver B", price: 0.37, profit: 3 },
         { name: "Driver C", price: 0.13, profit: 0 },
     ]);
-    const [setLastChanged] = useState(1);
+    const [, setLastChanged] = useState(1);
 
     const clamp = (v, min, max) => Math.max(min, Math.min(max, v));
 


### PR DESCRIPTION
## Summary
- Fix HedgeCalculator state bug by properly destructuring useState for last changed index

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895b48a0c1c83319c133d95e5673422