### PR TITLE
Fix profit slider getting stuck in middle position

### DIFF
--- a/src/HedgeCalculator.jsx
+++ b/src/HedgeCalculator.jsx
@@ -23,7 +23,11 @@ export default function HedgeCalculator() {
 
     /** Compute dynamic slider bounds so the full range is usable */
     const getProfitBounds = (profit) => {
-        const max = Math.max(profit * 2, 10);
+        // Using `profit * 2` as the upper bound caused the slider to track
+        // the current value, visually pinning the thumb to the middle of the
+        // track. Instead, grow the range linearly so the thumb position
+        // reflects the actual profit proportion.
+        const max = Math.max(profit + 10, 10);
         return { min: 0, max };
     };
 


### PR DESCRIPTION
## Summary
- adjust profit slider bounds to grow linearly so thumb reflects current value

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895eefe8f4083319268192aa657d977